### PR TITLE
Update gemspec

### DIFF
--- a/fluent-plugin-clouderametrics.gemspec
+++ b/fluent-plugin-clouderametrics.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "test-unit", "~> 3.0"
+  spec.add_development_dependency "webmock", "~> 2.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.10", "< 2"]
 end

--- a/fluent-plugin-clouderametrics.gemspec
+++ b/fluent-plugin-clouderametrics.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = "Input plugin for cloudera manager."
   spec.description   = spec.summary
-  spec.homepage      = "https://github.com/wesyao/fluent-plugin-clouderametrics"
+  spec.homepage      = "https://github.com/Microsoft/fluent-plugin-clouderametrics"
   spec.license       = "MIT"
 
   test_files, files  = `git ls-files -z`.split("\x0").partition do |f|


### PR DESCRIPTION
I've read the mail in Fluentd Google group:
https://groups.google.com/forum/?fromgroups#!topic/fluentd/7_ubT1XMey8

I've noticed that development dependency and homepage metadata in gemspec is outdated.